### PR TITLE
[WIP] PR review tracking

### DIFF
--- a/cmd/dns/cmd.go
+++ b/cmd/dns/cmd.go
@@ -35,7 +35,8 @@ func NewCmdValidateDns() *cobra.Command {
 	config := dnsConfig{}
 
 	validateDnsCmd := &cobra.Command{
-		Use: "dns",
+		Use:   "dns",
+		Short: "Verify any prerequisite DNS configuration is set as expected",
 		Run: func(cmd *cobra.Command, args []string) {
 
 			awsVerifier, err := utils.GetAwsVerifier(os.Getenv("AWS_REGION"), config.awsProfile, config.debug)

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -17,11 +17,11 @@ import (
 )
 
 var (
-	defaultTags               = map[string]string{"osd-network-verifier": "owned", "red-hat-managed": "true", "Name": "osd-network-verifier"}
-	awsRegionEnvVarStr string = "AWS_REGION"
-	awsRegionDefault   string = "us-east-2"
-	gcpRegionEnvVarStr string = "GCP_REGION"
-	gcpRegionDefault   string = "us-east1"
+	defaultTags        = map[string]string{"osd-network-verifier": "owned", "red-hat-managed": "true", "Name": "osd-network-verifier"}
+	awsRegionEnvVarStr = "AWS_REGION"
+	awsRegionDefault   = "us-east-2"
+	gcpRegionEnvVarStr = "GCP_REGION"
+	gcpRegionDefault   = "us-east1"
 )
 
 type egressConfig struct {
@@ -213,5 +213,4 @@ are set correctly before execution.
 	}
 
 	return validateEgressCmd
-
 }

--- a/cmd/egress/cmd.go
+++ b/cmd/egress/cmd.go
@@ -65,14 +65,14 @@ func NewCmdValidateEgress() *cobra.Command {
 
 	validateEgressCmd := &cobra.Command{
 		Use:   "egress",
-		Short: "Verify essential openshift domains are reachable from given subnet ID.",
-		Long:  `Verify essential openshift domains are reachable from given subnet ID.`,
+		Short: "Verify essential OpenShift domains are reachable from given subnet ID.",
+		Long:  `Verify essential OpenShift domains are reachable from given subnet ID.`,
 		Example: `For AWS, ensure your credential environment vars 
 AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (also AWS_SESSION_TOKEN for STS credentials) 
 are set correctly before execution.
 
-# Verify that essential openshift domains are reachable from a given SUBNET_ID
-./osd-network-verifier egress --subnet-id $(SUBNET_ID) --image-id $(IMAGE_ID)`,
+# Verify that essential OpenShift domains are reachable from a given SUBNET_ID
+./osd-network-verifier egress --subnet-id $(SUBNET_ID)`,
 		Run: func(cmd *cobra.Command, args []string) {
 
 			// Set Region
@@ -114,10 +114,10 @@ are set correctly before execution.
 			// AWS workflow
 			if !config.gcp {
 
-				//Setup AWS Secific Configs
+				//Setup AWS Specific Configs
 				vei.AWS = verifier.AwsEgressConfig{
 					KmsKeyID:        config.kmsKeyID,
-					SecurityGroupId: config.vpcSubnetID,
+					SecurityGroupId: config.securityGroupId,
 				}
 
 				awsVerifier, err := utils.GetAwsVerifier(config.region, config.awsProfile, config.debug)

--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 )
 
 func main() {
-
 	flags := pflag.NewFlagSet("osd-network-verifier", pflag.ExitOnError)
 
 	if err := flag.CommandLine.Parse([]string{}); err != nil {

--- a/pkg/verifier/aws/aws_verifier.go
+++ b/pkg/verifier/aws/aws_verifier.go
@@ -20,34 +20,38 @@ import (
 )
 
 var (
-	instanceCount int = 1
-	defaultAmi        = map[string]string{
-		// using Amazon Linux 2 AMI (HVM) - Kernel 5.10
-		"us-east-1":      "ami-0ed9277fb7eb570c9",
-		"us-east-2":      "ami-002068ed284fb165b",
-		"us-west-1":      "ami-03af6a70ccd8cb578",
-		"us-west-2":      "ami-00f7e5c52c0f43726",
-		"ca-central-1":   "ami-0bae7412735610274",
-		"eu-north-1":     "ami-06bfd6343550d4a29",
-		"eu-central-1":   "ami-05d34d340fb1d89e5",
-		"eu-west-1":      "ami-04dd4500af104442f",
-		"eu-west-2":      "ami-0d37e07bd4ff37148",
-		"eu-west-3":      "ami-0d3c032f5934e1b41",
-		"eu-south-1":     "ami-08d64ae428dd09b2a",
-		"ap-northeast-1": "ami-0218d08a1f9dac831",
-		"ap-northeast-2": "ami-0eb14fe5735c13eb5",
-		"ap-northeast-3": "ami-0f1ffb565070e6947",
-		"ap-east-1":      "ami-026e94842bffe7c42",
-		"ap-south-1":     "ami-052cef05d01020f1d",
-		"ap-southeast-1": "ami-0dc5785603ad4ff54",
-		"ap-southeast-2": "ami-0bd2230cfb28832f7",
-		"sa-east-1":      "ami-0056d4296b1120bc3",
-		"af-south-1":     "ami-060867d58b989c6be",
-		"me-south-1":     "ami-0483952b6a5997b06",
+	defaultAmi = map[string]string{
+		// using AMI from
+		"af-south-1":     "ami-0305ce24a63f7cd96",
+		"ap-east-1":      "ami-04b0c3f978c805497",
+		"ap-northeast-1": "ami-0f36dc8565e1204ac",
+		"ap-northeast-2": "ami-00e55c924048d51cd",
+		"ap-northeast-3": "ami-092632c2d4888ee15",
+		"ap-south-1":     "ami-027ee3c5ed1f1fbfc",
+		"ap-southeast-1": "ami-09f43282cd35a5b53",
+		"ap-southeast-2": "ami-0eb1973086a7b8a1a",
+		"ca-central-1":   "ami-08dc2cc48baa4a493",
+		"eu-central-1":   "ami-0a520b55e97ca808c",
+		"eu-north-1":     "ami-0d6c03859f2d5ba76",
+		"eu-south-1":     "ami-0af4bdc3e6f25374f",
+		"eu-west-1":      "ami-0949e6f98fdcc8a48",
+		"eu-west-2":      "ami-05af13545b8dcf09d",
+		"eu-west-3":      "ami-099c6b480ddecfa28",
+		"me-south-1":     "ami-08348a910dc888949",
+		"sa-east-1":      "ami-0e1e7df70438a9e28",
+		"us-east-1":      "ami-091db60579967890f",
+		"us-east-2":      "ami-09d6a8053437e16bf",
+		"us-west-1":      "ami-0cacfe7d77039ede2",
+		"us-west-2":      "ami-03ab344882b539e44",
 	}
+)
+
+const (
+	instanceCount int32 = 1
+
 	// TODO find a location for future docker images
-	networkValidatorImage string = "quay.io/app-sre/osd-network-verifier:v0.1.197-16fe250"
-	userdataEndVerifier   string = "USERDATA END"
+	networkValidatorImage = "quay.io/app-sre/osd-network-verifier:v0.1.212-5f88b83"
+	userdataEndVerifier   = "USERDATA END"
 )
 
 // AwsVerifier holds an aws client and knows how to fuifill the VerifierSerice which contains all functions needed for verifier
@@ -108,7 +112,7 @@ type createEC2InstanceInput struct {
 	userdata        string
 	KmsKeyID        string
 	securityGroupId string
-	instanceCount   int
+	instanceCount   int32
 	instanceType    string
 	tags            map[string]string
 	ctx             context.Context
@@ -125,7 +129,7 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 	}
 
 	eniSpecification := ec2Types.InstanceNetworkInterfaceSpecification{
-		AssociatePublicIpAddress: awsTools.Bool(true),
+		AssociatePublicIpAddress: awsTools.Bool(false),
 		DeviceIndex:              awsTools.Int32(0),
 		SubnetId:                 awsTools.String(input.SubnetID),
 	}
@@ -139,8 +143,8 @@ func (a *AwsVerifier) createEC2Instance(input createEC2InstanceInput) (string, e
 	// Build our request, converting the go base types into the pointers required by the SDK
 	instanceReq := ec2.RunInstancesInput{
 		ImageId:      awsTools.String(input.amiID),
-		MaxCount:     awsTools.Int32(int32(input.instanceCount)),
-		MinCount:     awsTools.Int32(int32(input.instanceCount)),
+		MaxCount:     awsTools.Int32(input.instanceCount),
+		MinCount:     awsTools.Int32(input.instanceCount),
 		InstanceType: ec2Types.InstanceType(input.instanceType),
 		// Because we're making this VPC aware, we also have to include a network interface specification
 		NetworkInterfaces: []ec2Types.InstanceNetworkInterfaceSpecification{eniSpecification},

--- a/pkg/verifier/aws/entry_point.go
+++ b/pkg/verifier/aws/entry_point.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/osd-network-verifier/pkg/verifier"
 )
 
-// validateEgress performs validation process for egress
+// ValidateEgress performs validation process for egress
 // Basic workflow is:
 // - prepare for ec2 instance creation
 // - create instance and wait till it gets ready, wait for userdata script execution
@@ -22,7 +22,7 @@ import (
 func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.Output {
 	a.writeDebugLogs(fmt.Sprintf("Using configured timeout of %s for each egress request", vei.Timeout.String()))
 
-	// Set default instanfe type if non is found
+	// Set default instance type if non is found
 	if vei.InstanceType == "" {
 		vei.InstanceType = "t3.micro"
 	}
@@ -34,7 +34,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	}
 
 	// Generate the userData file
-	// As expand replaces all ${var} (using empty srting for unknown ones), adding the env variables used in userdata.yaml
+	// As expand replaces all ${var} (using empty string for unknown ones), adding the env variables used in userdata.yaml
 	userDataVariables := map[string]string{
 		"AWS_REGION":               a.AwsClient.Region,
 		"USERDATA_BEGIN":           "USERDATA BEGIN",
@@ -94,7 +94,7 @@ func (a *AwsVerifier) ValidateEgress(vei verifier.ValidateEgressInput) *output.O
 	return &a.Output
 }
 
-// verifyDns performs verification process for VPC's DNS
+// VerifyDns performs verification process for VPC's DNS
 // Basic workflow is:
 // - ask AWS API for VPC attributes
 // - ensure they're set correctly


### PR DESCRIPTION
* `./osd-network-verifier dns` was missing a help text line
* atm we don't really want people to specify an `--image-id` so took that out of the example of the egress subcommand
* subnetId was being passed in as securityGroupId
* Use current latest AMIs/container images