### PR TITLE
Fix userdata logic around which image to use

### DIFF
--- a/pkg/helpers/config/userdata.yaml
+++ b/pkg/helpers/config/userdata.yaml
@@ -5,21 +5,59 @@ write_files:
     permissions: 755
     content: |
       #!/bin/bash
-      # based on tls, set up docker run command.
       echo "${USERDATA_BEGIN}" >> /var/log/userdata-output
-      sudo docker pull ${VALIDATOR_IMAGE} || echo "Warning: could not pull the specified docker image, will try to use the prepulled one" >> /var/log/userdata-output
-      VALIDATOR_REFERENCE=`echo ${VALIDATOR_IMAGE} | cut -d : -f 1`
-      # Retrieving the latest image successfully pulled (either from the script, or prepulled in the AMI)
-      IMAGE=`docker images ${VALIDATOR_REPO} -q  | head -n 2 | tail -n 1`
-      echo "Using IMAGE : $IMAGE" >> /var/log/userdata-output
-      if [[ "${CACERT}" != "" ]]; then
-        echo "${CACERT}" | base64 --decode > /proxy.pem
-        sudo docker run -v /proxy.pem:/proxy.pem -e "HTTP_PROXY=${HTTP_PROXY}" -e "HTTPS_PROXY=${HTTPS_PROXY}" --env "AWS_REGION=${AWS_REGION}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT} --cacert=/proxy.pem --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+
+      if podman pull ${VALIDATOR_IMAGE}; then
+        echo "Using IMAGE: $(podman images ${VALIDATOR_IMAGE} -q)" >> /var/log/userdata-output
+      
+        if [[ "${CACERT}" != "" ]]; then
+          echo "${CACERT}" | base64 --decode > /proxy.pem
+          podman run \
+            -v /proxy.pem:/proxy.pem \
+            --env "HTTP_PROXY=${HTTP_PROXY}" \
+            --env "HTTPS_PROXY=${HTTPS_PROXY}" \
+            --env "AWS_REGION=${AWS_REGION}" \
+            --env "START_VERIFIER=${VALIDATOR_START_VERIFIER}" \
+            --env "END_VERIFIER=${VALIDATOR_END_VERIFIER}" \
+            "$(podman images ${VALIDATOR_IMAGE} -q)" \
+            --cacert=/proxy.pem \
+            --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        else
+          podman run \
+            --env "AWS_REGION=${AWS_REGION}" \
+            --env "HTTP_PROXY=${HTTP_PROXY}" \
+            --env "START_VERIFIER=${VALIDATOR_START_VERIFIER}" \
+            --env "END_VERIFIER=${VALIDATOR_END_VERIFIER}" \
+            "$(podman images ${VALIDATOR_IMAGE} -q)" >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        fi
+
       else
-        sudo docker run --env "AWS_REGION=${AWS_REGION}" -e "HTTP_PROXY=${HTTP_PROXY}" -e "START_VERIFIER=${VALIDATOR_START_VERIFIER}" -e "END_VERIFIER=${VALIDATOR_END_VERIFIER}" ${IMAGE} --timeout=${TIMEOUT}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        echo "Warning: could not pull the specified docker image, will try to use the prepulled one" >> /var/log/userdata-output
+        echo "Using IMAGE: $(podman images quay.io/app-sre/osd-network-verifier -q | head -n 1)" >> /var/log/userdata-output
+      
+        if [[ "${CACERT}" != "" ]]; then
+          echo "${CACERT}" | base64 --decode > /proxy.pem
+          podman run \
+            -v /proxy.pem:/proxy.pem \
+            --env "HTTP_PROXY=${HTTP_PROXY}" \
+            --env "HTTPS_PROXY=${HTTPS_PROXY}" \
+            --env "AWS_REGION=${AWS_REGION}" \
+            --env "START_VERIFIER=${VALIDATOR_START_VERIFIER}" \
+            --env "END_VERIFIER=${VALIDATOR_END_VERIFIER}" \
+            "$(podman images quay.io/app-sre/osd-network-verifier} -q | head -n 1)" \
+            --cacert=/proxy.pem \
+            --no-tls=${NOTLS}  >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        else
+          podman run \
+            --env "AWS_REGION=${AWS_REGION}" \
+            --env "HTTP_PROXY=${HTTP_PROXY}" \
+            --env "START_VERIFIER=${VALIDATOR_START_VERIFIER}" \
+            --env "END_VERIFIER=${VALIDATOR_END_VERIFIER}" \
+            "$(podman images quay.io/app-sre/osd-network-verifier -q | head -n 1)" >> /var/log/userdata-output || echo "Failed to successfully run the docker container"
+        fi
       fi
+
       echo "${USERDATA_END}" >> /var/log/userdata-output
 runcmd:
-  - sudo service docker start 2>1 > /dev/null || echo "docker not started by systemctl"
   - /run-container.sh
   - cat /var/log/userdata-output >/dev/console


### PR DESCRIPTION
It works! Verified when using the pre-pulled image too:
```
❯ ./osd-network-verifier egress --subnet-id subnet-0ac95f663206a6bcc --region us-east-1        
Using region: us-east-1
Created instance with ID: i-0f4f6df8e3bda03e3
Summary:
printing out failures:
 -  egressURL error: Unable to reach route53domains.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach cert-api.access.redhat.com:443
 -  egressURL error: Unable to reach infogw.api.openshift.com:443
 -  egressURL error: Unable to reach quay-registry.s3.amazonaws.com:443
 -  egressURL error: Unable to reach api.openshift.com:443
 -  egressURL error: Unable to reach cart-rhcos-ci.s3.amazonaws.com:443
 -  egressURL error: Unable to reach registry.access.redhat.com:443
 -  egressURL error: Unable to reach events.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach route53.amazonaws.com:443
 -  egressURL error: Unable to reach sts.amazonaws.com:443
 -  egressURL error: Unable to reach registry.redhat.io:443
 -  egressURL error: Unable to reach events.pagerduty.com:443
 -  egressURL error: Unable to reach iam.amazonaws.com:443
 -  egressURL error: Unable to reach storage.googleapis.com:443
 -  egressURL error: Unable to reach api.deadmanssnitch.com:443
 -  egressURL error: Unable to reach pull.q1w2.quay.rhcloud.com:443
 -  egressURL error: Unable to reach cm-quay-production-s3.s3.amazonaws.com:443
 -  egressURL error: Unable to reach sso.redhat.com:80
 -  egressURL error: Unable to reach quay.io:443
 -  egressURL error: Unable to reach openshift.org:443
 -  egressURL error: Unable to reach mirror.openshift.com:443
 -  egressURL error: Unable to reach elasticloadbalancing.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach api.access.redhat.com:443
 -  egressURL error: Unable to reach tagging.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach ec2.amazonaws.com:443
 -  egressURL error: Unable to reach http-inputs-osdsecuritylogs.splunkcloud.com:443
 -  egressURL error: Unable to reach observatorium.api.openshift.com:443
 -  egressURL error: Unable to reach ec2.us-east-1.amazonaws.com:443
 -  egressURL error: Unable to reach console.redhat.com:443
 -  egressURL error: Unable to reach console.redhat.com:80
 -  egressURL error: Unable to reach sso.redhat.com:443
 -  egressURL error: Unable to reach nosnch.in:443
Failure!
```